### PR TITLE
Upgrade dockerfile

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,10 +1,10 @@
-FROM anapsix/alpine-java:8
+FROM openjdk:8-jdk-alpine
 
 # Install sbt
 ENV SBT_VERSION 0.13.17
 ENV SCALA_VERSION 2.11.7
 ENV PATH $PATH:/root/sbt/bin
-RUN apk add --no-cache curl=7.61.1-r1 && \
+RUN apk add --no-cache bash curl && \
   curl -fsL https://piccolo.link/sbt-$SBT_VERSION.tgz | gunzip -dc | tar xf - -C /root && \
   apk del curl
 


### PR DESCRIPTION
For loandocs, there is an extant bug in an older version of Alpine that [causes Chromium to segfault](https://github.com/gliderlabs/docker-alpine/issues/444) on certain host platforms.

While attempting to research a workaround, I discovered that the base image we previously used, [`anapsix/alpine-java`](https://hub.docker.com/r/anapsix/alpine-java/), is deprecated because Oracle no longer supports that use of their JDK. Because of this, we needed to move to [OpenJDK](https://hub.docker.com/_/openjdk) eventually, so I also fixed that.

I do wonder about the image tagging though, how should we designate that this image is a major revision from the previous one?

